### PR TITLE
EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# semigroups ![Continuous Integration](https://github.com/typelevel/semigroups/workflows/Continuous%20Integration/badge.svg) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.chrisdavenport/semigroups_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.chrisdavenport/semigroups_2.12)
+# semigroups
+
+## This library has moved to [another repository](https://github.com/typelevel/monoids). 
 
 Set of Generic Semigroup Types and Accompanying Instances very useful for abstract programming.
 


### PR DESCRIPTION
We've combined `monoids` and `semigroups` (https://github.com/typelevel/monoids/pull/244), so we are free to archive this repository.